### PR TITLE
mailservice: add documentation to mailer interface

### DIFF
--- a/mailservice/src/main/kotlin/com/clouway/mailservice/core/Mailer.kt
+++ b/mailservice/src/main/kotlin/com/clouway/mailservice/core/Mailer.kt
@@ -1,8 +1,20 @@
 package com.clouway.mailservice.core
 
 /**
+ * Sends an email to a receiver with
+ * a title and content.
+ *
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 interface Mailer {
+
+    /**
+     * Sends an email.
+     *
+     * @param receiver Receiver of the email
+     * @param title Title of the email
+     * @param content Content of the email
+     * @return A status code
+     */
     fun mail(receiver: String, title: String, content: String): Int
 }


### PR DESCRIPTION
Added documentation to mailer interface. Closes #16.