### PR TITLE
pubsub: pass event type and time to register request

### DIFF
--- a/pubsub/src/main/kotlin/com/clouway/pubsub/adapter/google/pubsub/AsyncPubsubEventBus.kt
+++ b/pubsub/src/main/kotlin/com/clouway/pubsub/adapter/google/pubsub/AsyncPubsubEventBus.kt
@@ -29,6 +29,8 @@ internal class AsyncPubsubEventBus(private val publisherProvider: PublisherProvi
             val eventType = messageWrapper.message.getEventType()
             val handler = handlers[eventType]
             val event = Gson().fromJson(messageWrapper.message.decodeData(), eventType)
+            req.attribute("eventType", eventType.name)
+            req.attribute("time", messageWrapper.message.getTime())
             req.attribute("event", event)
             handler?.handle(req, res) ?: res.status(HttpStatus.NO_CONTENT_204)
         }

--- a/pubsub/src/main/kotlin/com/clouway/pubsub/adapter/google/pubsub/JsonPubsubMessage.kt
+++ b/pubsub/src/main/kotlin/com/clouway/pubsub/adapter/google/pubsub/JsonPubsubMessage.kt
@@ -1,11 +1,19 @@
 package com.clouway.pubsub.adapter.google.pubsub
 
+import com.google.appengine.repackaged.com.google.gson.Gson
+import java.time.LocalDateTime
 import java.util.*
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
 data class JsonPubsubMessage(val attributes: Map<String, String>, val data: String, val messageId: String){
+
+    fun getTime(): LocalDateTime {
+        val gson = Gson()
+        return gson.fromJson(attributes["time"], LocalDateTime::class.java)
+    }
+
     fun getEventType(): Class<*>{
         println(attributes["eventType"])
         return Class.forName(attributes["eventType"])

--- a/pubsub/src/main/kotlin/com/clouway/pubsub/adapter/google/pubsub/PubsubEventConverter.kt
+++ b/pubsub/src/main/kotlin/com/clouway/pubsub/adapter/google/pubsub/PubsubEventConverter.kt
@@ -5,15 +5,20 @@ import com.clouway.pubsub.core.event.Event
 import com.google.appengine.repackaged.com.google.gson.Gson
 import com.google.protobuf.ByteString
 import com.google.pubsub.v1.PubsubMessage
+import java.time.LocalDateTime
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-internal class PubsubEventConverter : EventConverter<PubsubMessage> {
+internal class PubsubEventConverter(private val getInstant: () -> LocalDateTime = { LocalDateTime.now()})
+    : EventConverter<PubsubMessage> {
     override fun convertEvent(event: Event, eventType: Class<*>): PubsubMessage {
         val gson = Gson()
         val jsonEvent = gson.toJson(event)
         val data = ByteString.copyFromUtf8(jsonEvent)
-        return PubsubMessage.newBuilder().setData(data).putAttributes("eventType", eventType.name).build()
+        return PubsubMessage.newBuilder().setData(data)
+                .putAttributes("eventType", eventType.name)
+                .putAttributes("time", gson.toJson(getInstant()))
+                .build()
     }
 }

--- a/pubsub/src/test/kotlin/com/clouway/pubsub/adapter/google/pubsub/GooglePubsubTest.kt
+++ b/pubsub/src/test/kotlin/com/clouway/pubsub/adapter/google/pubsub/GooglePubsubTest.kt
@@ -19,6 +19,7 @@ import spark.Request
 import spark.Response
 import sun.reflect.generics.reflectiveObjects.NotImplementedException
 import java.io.InputStream
+import java.time.LocalDateTime
 import javax.servlet.ReadListener
 import javax.servlet.ServletInputStream
 import javax.servlet.http.HttpServletRequest
@@ -62,20 +63,25 @@ class GooglePubsubTest {
     private val testEventJson = """
         {"data":"::data::"}
     """.trimIndent()
-    private val testConverter = PubsubEventConverter()
+
+    private val testInstant = LocalDateTime.of(1, 1, 1, 1, 1, 1)
+    private val jsonTestInstant = Gson().toJson(testInstant)
+    private val testConverter = PubsubEventConverter(getInstant = {testInstant})
 
     private val testPubsubMessage = createTestPubsubMessage(testEventJson)
 
     private fun createTestPubsubMessage(eventJson: String): PubsubMessage {
         val data = ByteString.copyFromUtf8(eventJson)
-        return PubsubMessage.newBuilder().setData(data).putAttributes("eventType", TestEvent::class.jvmName).build()
+        return PubsubMessage.newBuilder().setData(data).putAttributes("eventType", TestEvent::class.jvmName)
+                .putAttributes("time", jsonTestInstant).build()
     }
 
     private val requsestEncodedJson = """
         {
     "message": {
     "attributes": {
-      "eventType": "${TestEvent::class.java.name}"
+      "eventType": "${TestEvent::class.java.name}",
+      "time": '$jsonTestInstant'
     },
     "data": "eyJkYXRhIjoiOjpkYXRhOjoifQ==",
     "message_id": "136969346945"


### PR DESCRIPTION
Passed the event type and time to the request in the event bus register function. Recorded the time of creation in the event converter class. Closes #20.