### PR TITLE
gradle: move dependencies into microservices

### DIFF
--- a/bankapp/build.gradle
+++ b/bankapp/build.gradle
@@ -1,6 +1,29 @@
 apply plugin: 'war'
+apply plugin: 'appengine'
+
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        jcenter()
+    }
+
+    dependencies {
+        classpath "com.google.appengine:gradle-appengine-plugin:$appenginePluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60"
+    }
+}
 
 dependencies {
+    appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
     compile project (':entityhelper')
+    compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
+    compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+    testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
+            "com.google.appengine:appengine-testing:$appengineSdkVersion"
+}
+
+appengine {
+    downloadSdk = true
 }

--- a/bankapp/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/bankapp/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>bankapp</application>
+    <application>sacred-union-210613</application>
     <version>1</version>
 
     <runtime>java8</runtime>

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'ear'
 apply plugin: 'appengine'
 
 buildscript {
+
+    ext.appenginePluginVersion = "1.9.59"
+    ext.appengineSdkVersion = "1.9.64"
+
     repositories {
         mavenCentral()
         mavenLocal()
@@ -10,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.google.appengine:gradle-appengine-plugin:1.9.59"
+        classpath "com.google.appengine:gradle-appengine-plugin:$appenginePluginVersion"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60'
     }
 }
@@ -32,14 +36,7 @@ subprojects {
     apply plugin: 'kotlin'
 
     dependencies {
-        compile 'com.google.cloud:google-cloud-pubsub:1.35.0'
-
         compile 'javax.servlet:javax.servlet-api:3.1.0'
-
-        compile "com.google.appengine:appengine-api-1.0-sdk:1.9.59"
-        compile "com.google.appengine:appengine-tools-sdk:1.9.59"
-
-        compile 'com.google.guava:guava:19.0'
 
         compile 'com.sparkjava:spark-core:2.5.4'
         compile "com.sparkjava:spark-kotlin:1.0.0-alpha"
@@ -52,13 +49,12 @@ subprojects {
         testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.8.4'
         testCompile "org.jetbrains.kotlin:kotlin-test:1.2.51"
         testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.2.51"
-        testCompile "com.google.appengine:appengine-api-stubs:1.9.59", "com.google.appengine:appengine-testing:1.9.59"
     }
 }
 
 
 dependencies {
-    appengineSdk "com.google.appengine:appengine-java-sdk:1.9.59"
+    appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     deploy project(path: ':bankapp', configuration: 'archives')
     deploy project(path: ':mailservice', configuration: 'archives')
     deploy project(path: ':loggingservice', configuration: 'archives')

--- a/entityhelper/build.gradle
+++ b/entityhelper/build.gradle
@@ -1,0 +1,6 @@
+dependencies{
+    compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
+    compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+    testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
+            "com.google.appengine:appengine-testing:$appengineSdkVersion"
+}

--- a/loggingservice/build.gradle
+++ b/loggingservice/build.gradle
@@ -1,6 +1,29 @@
 apply plugin: 'war'
+apply plugin: 'appengine'
+
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        jcenter()
+    }
+
+    dependencies {
+        classpath "com.google.appengine:gradle-appengine-plugin:$appenginePluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60"
+    }
+}
 
 dependencies {
+    appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
     compile project (':entityhelper')
+    compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
+    compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+    testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
+            "com.google.appengine:appengine-testing:$appengineSdkVersion"
+}
+
+appengine {
+    downloadSdk = true
 }

--- a/loggingservice/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/loggingservice/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>log</application>
+    <application>sacred-union-210613</application>
     <version>v1</version>
 
     <module>log</module>

--- a/mailservice/build.gradle
+++ b/mailservice/build.gradle
@@ -1,6 +1,30 @@
 apply plugin: 'war'
+apply plugin: 'appengine'
+
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        jcenter()
+    }
+
+    dependencies {
+        classpath "com.google.appengine:gradle-appengine-plugin:$appenginePluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60"
+    }
+}
+
 
 dependencies {
+    appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
     compile 'com.sendgrid:sendgrid-java:4.0.1'
+    compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
+    compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+    testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
+            "com.google.appengine:appengine-testing:$appengineSdkVersion"
+}
+
+appengine {
+    downloadSdk = true
 }

--- a/mailservice/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/mailservice/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>mail</application>
+    <application>sacred-union-210613</application>
     <version>v1</version>
 
     <module>mail</module>

--- a/pubsub/build.gradle
+++ b/pubsub/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    compile 'com.google.cloud:google-cloud-pubsub:1.35.0'
+    compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
+    compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+    testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
+            "com.google.appengine:appengine-testing:$appengineSdkVersion"
+}


### PR DESCRIPTION
Moved microservice appengine dependencies into their own gradle build files. Closes #54.