### PR TITLE
mail-service: move sendgrid api key to gcs

### DIFF
--- a/mailservice/build.gradle
+++ b/mailservice/build.gradle
@@ -18,7 +18,11 @@ buildscript {
 dependencies {
     appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
+
     compile 'com.sendgrid:sendgrid-java:4.0.1'
+    compile ('com.google.appengine.tools:appengine-gcs-client:0.8')  {
+        exclude group: 'com.google.guava'
+    }
     compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
     compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
     testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",

--- a/mailservice/src/main/kotlin/com/clouway/mailservice/core/SendGridMailer.kt
+++ b/mailservice/src/main/kotlin/com/clouway/mailservice/core/SendGridMailer.kt
@@ -7,14 +7,14 @@ import java.io.IOException
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-class SendGridMailer : Mailer {
+class SendGridMailer(private val apikey: String) : Mailer {
     override fun mail(receiver: String, title: String, content: String): Int {
         val from = Email("admin@sacred-union.com")
         val to = Email(receiver)
         val mailContent = Content("text/plain", content)
         val mail = Mail(from, title, to, mailContent)
 
-        val sg = SendGrid(System.getProperty("sendgrid_api_key"))
+        val sg = SendGrid(apikey)
         val request = Request()
         return try {
             request.method = Method.POST

--- a/mailservice/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/mailservice/src/main/webapp/WEB-INF/appengine-web.xml
@@ -14,7 +14,6 @@
     </automatic-scaling>
 
     <system-properties>
-        <property name="sendgrid_api_key" value="api-key"/>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
     </system-properties>
 

--- a/mailservice/src/test/kotlin/adapter/spark/MailSystemTest.kt
+++ b/mailservice/src/test/kotlin/adapter/spark/MailSystemTest.kt
@@ -2,6 +2,7 @@ package adapter.spark
 
 import com.clouway.mailservice.adapter.spark.MailEventHandler
 import com.clouway.mailservice.core.Mailer
+import com.clouway.mailservice.core.SendGridMailer
 import org.eclipse.jetty.http.HttpStatus
 import org.jmock.AbstractExpectations.returnValue
 import org.jmock.Expectations
@@ -60,5 +61,5 @@ class MailSystemTest {
 
         assertThat(mailHandler.handle(req, res) as Int, Is(HttpStatus.OK_200))
     }
-    
+
 }


### PR DESCRIPTION
Moved the sendgrid api key to the google cloud store and passed it to the sendgrid mailer in the configuration file. Closes #56.