### PR TITLE
entityhelper: remove servlet, spark and jmock dependencies

### DIFF
--- a/bankapp/build.gradle
+++ b/bankapp/build.gradle
@@ -18,8 +18,18 @@ dependencies {
     appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
     compile project (':entityhelper')
+
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
+
+    compile 'com.sparkjava:spark-core:2.5.4'
+    compile "com.sparkjava:spark-kotlin:1.0.0-alpha"
+
     compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
     compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+    testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.8.4'
+    testCompile "org.jetbrains.kotlin:kotlin-test:1.2.51"
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.2.51"
     testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
             "com.google.appengine:appengine-testing:$appengineSdkVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,19 +36,10 @@ subprojects {
     apply plugin: 'kotlin'
 
     dependencies {
-        compile 'javax.servlet:javax.servlet-api:3.1.0'
-
-        compile 'com.sparkjava:spark-core:2.5.4'
-        compile "com.sparkjava:spark-kotlin:1.0.0-alpha"
         compile 'org.slf4j:slf4j-simple:1.7.25'
         compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
         compile 'org.jetbrains.kotlin:kotlin-reflect:1.2.51'
         compile 'org.apache.commons:commons-lang3:3.7'
-
-        testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-        testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.8.4'
-        testCompile "org.jetbrains.kotlin:kotlin-test:1.2.51"
-        testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.2.51"
     }
 }
 

--- a/loggingservice/build.gradle
+++ b/loggingservice/build.gradle
@@ -18,8 +18,19 @@ dependencies {
     appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
     compile project (':entityhelper')
+
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
+
+    compile 'com.sparkjava:spark-core:2.5.4'
+    compile "com.sparkjava:spark-kotlin:1.0.0-alpha"
+
     compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
     compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+
+    testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.8.4'
+    testCompile "org.jetbrains.kotlin:kotlin-test:1.2.51"
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.2.51"
     testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
             "com.google.appengine:appengine-testing:$appengineSdkVersion"
 }

--- a/mailservice/build.gradle
+++ b/mailservice/build.gradle
@@ -19,12 +19,22 @@ dependencies {
     appengineSdk "com.google.appengine:appengine-java-sdk:$appengineSdkVersion"
     compile project (':pubsub')
 
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
+
+    compile 'com.sparkjava:spark-core:2.5.4'
+    compile "com.sparkjava:spark-kotlin:1.0.0-alpha"
+
     compile 'com.sendgrid:sendgrid-java:4.0.1'
     compile ('com.google.appengine.tools:appengine-gcs-client:0.8')  {
         exclude group: 'com.google.guava'
     }
     compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
     compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+
+    testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.8.4'
+    testCompile "org.jetbrains.kotlin:kotlin-test:1.2.51"
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.2.51"
     testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
             "com.google.appengine:appengine-testing:$appengineSdkVersion"
 }

--- a/pubsub/build.gradle
+++ b/pubsub/build.gradle
@@ -2,6 +2,16 @@ dependencies {
     compile 'com.google.cloud:google-cloud-pubsub:1.35.0'
     compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
     compile "com.google.appengine:appengine-tools-sdk:$appengineSdkVersion"
+
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
+
+    compile 'com.sparkjava:spark-core:2.5.4'
+    compile "com.sparkjava:spark-kotlin:1.0.0-alpha"
+
+    testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.8.4'
+    testCompile "org.jetbrains.kotlin:kotlin-test:1.2.51"
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:1.2.51"
     testCompile "com.google.appengine:appengine-api-stubs:$appengineSdkVersion",
             "com.google.appengine:appengine-testing:$appengineSdkVersion"
 }


### PR DESCRIPTION
Removed unused dependencies from entity helper and inserted them into the modules that really use them. Closes #59.