### PR TITLE
cache: decoupled persistence and cache services

### DIFF
--- a/bankapp/src/main/kotlin/com/clouway/bankapp/adapter/gae/memcache/MemcacheSessions.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/adapter/gae/memcache/MemcacheSessions.kt
@@ -1,18 +1,17 @@
 package com.clouway.bankapp.adapter.gae.memcache
 
-import com.clouway.bankapp.core.*
+import com.clouway.bankapp.core.Cache
+import com.clouway.bankapp.core.Session
 import com.clouway.entityhelper.TypedEntity
 import com.google.appengine.api.datastore.Entity
 import com.google.appengine.api.memcache.MemcacheService
 import com.google.appengine.api.memcache.MemcacheServiceFactory
-import java.time.LocalDateTime
-import java.util.*
+import java.util.Optional
 
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-class MemcacheSessions(private val origin: Sessions)
-    : Sessions {
+class MemcacheSessions: Cache<Session> {
 
     private val ID_PREFIX = "sid"
     private val SESSION_KIND = "Session"
@@ -20,39 +19,23 @@ class MemcacheSessions(private val origin: Sessions)
     private val service: MemcacheService
         get() = MemcacheServiceFactory.getMemcacheService()
 
-    override fun getSessionAvailableAt(sessionId: String, date: LocalDateTime): Optional<Session> {
-
-        val cachedSession = service.get(key(sessionId)) ?: return origin.getSessionAvailableAt(sessionId, date)
-
-        val mappedSession = mapEntityToSession(cachedSession as Entity)
-
-        return if(mappedSession.expiresOn.isBefore(date)) {
-            terminateSession(sessionId)
-            Optional.empty()
-        }
-        else{
-            Optional.of(mappedSession)
-        }
+    override fun put(obj: Session): Session {
+        val sessionEntity = mapSessionToEntity(obj)
+        service.put(prefixKey(obj.sessionId), sessionEntity)
+        return obj
     }
 
-    override fun issueSession(sessionRequest: SessionRequest): Session {
-        val session = origin.issueSession(sessionRequest)
-        saveSessionInCache(session)
-        return session
+    override fun get(key: String): Optional<Session> {
+        val cachedSession = service.get(prefixKey(key)) ?: return Optional.empty()
+
+        return Optional.of(mapEntityToSession(cachedSession as Entity))
     }
 
-    override fun terminateSession(sessionId: String) {
-        origin.terminateSession(sessionId)
-
-        service.delete(key(sessionId))
+    override fun remove(key: String) {
+        service.delete(prefixKey(key))
     }
 
-    private fun saveSessionInCache(session: Session) {
-        val sessionEntity = mapSessionToEntity(session)
-        service.put(key(session.sessionId), sessionEntity)
-    }
-
-    private fun key(key: Any): String{
+    private fun prefixKey(key: Any): String{
         return "${ID_PREFIX}_$key"
     }
 

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/Cache.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/Cache.kt
@@ -1,0 +1,12 @@
+package com.clouway.bankapp.core
+
+import java.util.Optional
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+interface Cache<T> {
+    fun put(obj:  T): T
+    fun get(key: String): Optional<T>
+    fun remove(key: String)
+}

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemorySessions.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemorySessions.kt
@@ -1,0 +1,36 @@
+package com.clouway.bankapp.core
+
+import java.time.LocalDateTime
+import java.util.Optional
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class InMemorySessions: Sessions {
+
+    private val persistentMap = mutableMapOf<String, Session>()
+
+    override fun issueSession(sessionRequest: SessionRequest): Session {
+        val session = Session(
+                sessionRequest.userId,
+                sessionRequest.sessionId,
+                sessionRequest.expiration,
+                sessionRequest.username,
+                sessionRequest.userEmail,
+                true
+        )
+        persistentMap[session.sessionId] = session
+        return session
+    }
+
+    override fun terminateSession(sessionId: String) {
+        persistentMap.remove(sessionId)
+    }
+
+    override fun getSessionAvailableAt(sessionId: String, date: LocalDateTime): Optional<Session> {
+        val session = persistentMap[sessionId] ?: return Optional.empty()
+
+        return if(session.expiresOn.isBefore(date)) Optional.empty()
+        else Optional.of(session)
+    }
+}

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemorySessionsCache.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemorySessionsCache.kt
@@ -1,0 +1,25 @@
+package com.clouway.bankapp.core
+
+import java.util.Optional
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class InMemorySessionsCache: Cache<Session> {
+
+    private val cacheMap = mutableMapOf<String, Session>()
+
+    override fun put(obj: Session): Session {
+        cacheMap[obj.sessionId] = obj
+        return obj
+    }
+
+    override fun get(key: String): Optional<Session> {
+        val cachedSession = cacheMap[key] ?: return Optional.empty()
+        return Optional.of(cachedSession)
+    }
+
+    override fun remove(key: String) {
+        cacheMap.remove(key)
+    }
+}

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemoryUsers.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemoryUsers.kt
@@ -1,0 +1,47 @@
+package com.clouway.bankapp.core
+
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class InMemoryUsers : Users {
+
+    private val persistentMap = mutableMapOf<String, User>()
+
+    override fun getById(id: String): Optional<User> {
+        val possibleUser = persistentMap[id] ?: return Optional.empty()
+        return Optional.of(possibleUser)
+    }
+
+    override fun deleteById(id: String) {
+        val possibleUser = persistentMap[id] ?: return
+        persistentMap.remove(possibleUser.username)
+        persistentMap.remove(possibleUser.id)
+    }
+
+    override fun update(user: User) {
+        persistentMap[user.id] = user
+        persistentMap[user.username] = user
+    }
+
+    override fun getByUsername(username: String): Optional<User> {
+        val possibleUser = persistentMap[username] ?: return Optional.empty()
+        return Optional.of(possibleUser)
+    }
+
+    @Throws(UserAlreadyExistsException::class)
+    override fun registerIfNotExists(registerRequest: UserRegistrationRequest): User {
+        if(persistentMap[registerRequest.username] != null) throw UserAlreadyExistsException()
+        val user = User(
+                UUID.randomUUID().toString(),
+                registerRequest.username,
+                registerRequest.email,
+                registerRequest.password
+        )
+        persistentMap[user.id] = user
+        persistentMap[user.username] = user
+        return user
+    }
+}

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemoryUsersCache.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/InMemoryUsersCache.kt
@@ -1,0 +1,28 @@
+package com.clouway.bankapp.core
+
+import java.util.Optional
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class InMemoryUsersCache : Cache<User> {
+
+    private val cacheMap = mutableMapOf<String, User>()
+
+    override fun put(obj: User): User {
+        cacheMap[obj.id] = obj
+        cacheMap[obj.username] = obj
+        return obj
+    }
+
+    override fun get(key: String): Optional<User> {
+        val cachedUser = cacheMap[key] ?: return Optional.empty()
+        return Optional.of(cachedUser)
+    }
+
+    override fun remove(key: String) {
+        val cachedUser = cacheMap[key] ?: return
+        cacheMap.remove(cachedUser.id)
+        cacheMap.remove(cachedUser.username)
+    }
+}

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/SessionsDecorator.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/SessionsDecorator.kt
@@ -1,0 +1,57 @@
+package com.clouway.bankapp.core
+
+import java.time.LocalDateTime
+import java.util.Optional
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class SessionsDecorator(private val cacheService: Cache<Session>,
+                        private val decorated: Sessions) : Sessions {
+
+
+    /**
+     * Creates a session object and saves it into persistence and cache.
+     *
+     * @param sessionRequest The request to be converted to an object
+     * @return The created Session object
+     */
+    override fun issueSession(sessionRequest: SessionRequest): Session {
+        val session = decorated.issueSession(sessionRequest)
+        cacheService.put(session)
+        return session
+    }
+
+    /**
+     * Removes a session from persistence and cache.
+     *
+     * @param sessionId The id of the session to be removed
+     */
+    override fun terminateSession(sessionId: String) {
+        cacheService.remove(sessionId)
+        decorated.terminateSession(sessionId)
+    }
+
+    /**
+     * Retrieves a session from the cache or persistence, if a cached session
+     * is not present, but a persistent session is, then saves the persistent session to the
+     * cache.
+     *
+     * @param sessionId The id of the session
+     * @param date The latest date the session can have as expiration
+     * @return The optionally found session
+     */
+    override fun getSessionAvailableAt(sessionId: String, date: LocalDateTime): Optional<Session> {
+        val cachedSession = cacheService.get(sessionId)
+
+        return if(cachedSession.isPresent){
+            val retrievedSession = cachedSession.get()
+            if(retrievedSession.expiresOn.isBefore(date)) Optional.empty()
+            else cachedSession
+        }else {
+            val persistentSession = decorated.getSessionAvailableAt(sessionId, date)
+            if(persistentSession.isPresent) cacheService.put(persistentSession.get())
+            persistentSession
+        }
+    }
+}

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/UsersDecorator.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/UsersDecorator.kt
@@ -1,0 +1,79 @@
+package com.clouway.bankapp.core
+
+import java.util.Optional
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class UsersDecorator(private val cacheService: Cache<User>,
+                     private val decorated: Users) : Users{
+
+    /**
+     * Returns a user by id from the cache, if
+     * the user is not found in the cache but found in persistence
+     * then the user is cached before being returned.
+     *
+     * @param id The id of the user
+     * @return An optional User
+     */
+    override fun getById(id: String): Optional<User> {
+        val cachedUser = cacheService.get(id)
+        return if(cachedUser.isPresent) cachedUser
+        else{
+            val persistentUser = decorated.getById(id)
+            if(persistentUser.isPresent) cacheService.put(persistentUser.get())
+            persistentUser
+        }
+    }
+
+    /**
+     * Returns a user by username from the cache, if
+     * the user is not found in the cache but found in persistence
+     * then the user is cached before being returned.
+     *
+     * @param username The username of the user
+     * @return An optional User
+     */
+    override fun getByUsername(username: String): Optional<User> {
+        val cachedUser = cacheService.get(username)
+        return if(cachedUser.isPresent) cachedUser
+        else{
+            val persistentUser = decorated.getByUsername(username)
+            if(persistentUser.isPresent) cacheService.put(persistentUser.get())
+            persistentUser
+        }
+    }
+
+    /**
+     * Deletes a user by id.
+     *
+     * @param id The id of the user to delete
+     */
+    override fun deleteById(id: String) {
+        decorated.deleteById(id)
+        cacheService.remove(id)
+    }
+
+    /**
+     * Updates a user in persistence and in the cache.
+     *
+     * @param user The updates User
+     */
+    override fun update(user: User) {
+        decorated.update(user)
+        cacheService.put(user)
+    }
+
+    /**
+     * Registers a user and caches him, or throws a UserAlreadyExistsException.
+     *
+     * @param registerRequest The registration request
+     * @return The registered User
+     */
+    @Throws(UserAlreadyExistsException::class)
+    override fun registerIfNotExists(registerRequest: UserRegistrationRequest): User {
+        val registeredUser = decorated.registerIfNotExists(registerRequest)
+        cacheService.put(registeredUser)
+        return registeredUser
+    }
+}

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/datastore/DatastoreUsersTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/datastore/DatastoreUsersTest.kt
@@ -28,7 +28,7 @@ class DatastoreUsersTest {
     fun returnRegisteredUser(){
         val user = userRepo.registerIfNotExists(registrationRequest)
 
-        assertThat(userRepo.getById(user.id).get() == user, Is(true))
+        assertThat(userRepo.getById(user.id).get(), Is(user))
     }
 
     @Test(expected = UserAlreadyExistsException::class)

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/memcache/MemcacheUsersTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/memcache/MemcacheUsersTest.kt
@@ -2,13 +2,9 @@ package com.clouway.bankapp.adapter.memcache
 
 import com.clouway.bankapp.adapter.gae.memcache.MemcacheUsers
 import com.clouway.bankapp.core.*
-import com.google.appengine.api.memcache.MemcacheServiceFactory
-import org.jmock.AbstractExpectations.returnValue
-import org.jmock.AbstractExpectations.throwException
 import org.jmock.Expectations
 import org.jmock.Mockery
 import org.jmock.integration.junit4.JUnitRuleMockery
-import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import rule.MemcacheRule
@@ -26,137 +22,45 @@ class MemcacheUsersTest {
     @JvmField
     val helper: MemcacheRule = MemcacheRule()
 
-    private fun Mockery.expecting(block: Expectations.() -> Unit){
-        checking(Expectations().apply(block))
-    }
+    private val user = User("::id::", "::username::", "::email::", "::password::")
 
-    @Rule
-    @JvmField
-    val context: JUnitRuleMockery = JUnitRuleMockery()
+    private val usersCache = MemcacheUsers()
 
-    private val testId = UUID.randomUUID().toString()
+    @Test
+    fun saveUserInCache(){
 
-    private val testUser = User(testId, "::username::", "::email::", "::password::")
-    private val testRegistrationRequest = UserRegistrationRequest("::username::", "::email::", "::password::")
-
-    private val mockPersistentRepository = context.mock(Users::class.java)
-
-    private val userMemcacheRepo = MemcacheUsers(mockPersistentRepository)
-
-    private val idPrefix = "user"
-
-    @After
-    fun cleanUp(){
-        MemcacheServiceFactory.getMemcacheService().delete(key(testUser.id))
-        MemcacheServiceFactory.getMemcacheService().delete(key(testUser.username))
+        assertThat(usersCache.put(user), Is(user))
     }
 
     @Test
-    fun shouldRegisterUserInCache(){
+    fun retrieveUserFromCache(){
+        usersCache.put(user)
 
-        context.expecting {
-            oneOf(mockPersistentRepository).registerIfNotExists(testRegistrationRequest)
-            will(returnValue(testUser))
-        }
-
-        assertThat(userMemcacheRepo.registerIfNotExists(testRegistrationRequest), Is(testUser))
-    }
-
-    @Test (expected = UserAlreadyExistsException::class)
-    fun shouldNotRegisterAUserTwice(){
-
-        context.expecting {
-            oneOf(mockPersistentRepository).registerIfNotExists(testRegistrationRequest)
-            will(returnValue(testUser))
-
-            oneOf(mockPersistentRepository).registerIfNotExists(testRegistrationRequest)
-            will(throwException(UserAlreadyExistsException()))
-        }
-
-        userMemcacheRepo.registerIfNotExists(testRegistrationRequest)
-        userMemcacheRepo.registerIfNotExists(testRegistrationRequest)
+        assertThat(usersCache.get(user.username).get(), Is(user))
+        assertThat(usersCache.get(user.id).get(), Is(user))
     }
 
     @Test
-    fun shouldRetrieveUserFromCache(){
-
-        context.expecting {
-            oneOf(mockPersistentRepository).registerIfNotExists(testRegistrationRequest)
-            will(returnValue(testUser))
-        }
-
-        userMemcacheRepo.registerIfNotExists(testRegistrationRequest)
-        assertThat(userMemcacheRepo.getByUsername(testUser.username).get(), Is(testUser))
-        assertThat(userMemcacheRepo.getById(testUser.id).get(), Is(testUser))
+    fun returnEmptyWhenNotFound(){
+        assertThat(usersCache.get(user.username).isPresent, Is(false))
+        assertThat(usersCache.get(user.id).isPresent, Is(false))
     }
 
     @Test
-    fun shouldRetrieveUserFromPersistence(){
+    fun deleteUserFromCacheById(){
+        usersCache.put(user)
+        usersCache.remove(user.id)
 
-        context.expecting {
-            oneOf(mockPersistentRepository).getByUsername(testUser.username)
-            will(returnValue(Optional.of(testUser)))
-            oneOf(mockPersistentRepository).getById(testUser.id)
-            will(returnValue(Optional.of(testUser)))
-        }
-
-        assertThat(userMemcacheRepo.getByUsername(testUser.username).get(), Is(testUser))
-        assertThat(userMemcacheRepo.getById(testUser.id).get(), Is(testUser))
+        assertThat(usersCache.get(user.id).isPresent, Is(false))
+        assertThat(usersCache.get(user.username).isPresent, Is(false))
     }
 
     @Test
-    fun shouldReturnEmptyWhenNotFound(){
+    fun deleteUserFromCacheByUsername(){
+        usersCache.put(user)
+        usersCache.remove(user.username)
 
-        context.expecting {
-            oneOf(mockPersistentRepository).getByUsername(testUser.username)
-            will(returnValue(Optional.empty<User>()))
-            oneOf(mockPersistentRepository).getById(testUser.id)
-            will(returnValue(Optional.empty<User>()))
-        }
-
-        assertThat(userMemcacheRepo.getByUsername(testUser.username).isPresent, Is(false))
-        assertThat(userMemcacheRepo.getById(testUser.id).isPresent, Is(false))
-    }
-
-    @Test
-    fun shouldUpdateUserInCache(){
-        val updatedUser = User(testId, "::username::", "::new-email::", "::password::")
-
-        context.expecting {
-            oneOf(mockPersistentRepository).registerIfNotExists(testRegistrationRequest)
-            will(returnValue(testUser))
-
-            oneOf(mockPersistentRepository).update(updatedUser)
-        }
-
-        userMemcacheRepo.registerIfNotExists(testRegistrationRequest)
-        userMemcacheRepo.update(updatedUser)
-        assertThat(userMemcacheRepo.getByUsername(testUser.username).get().email, Is("::new-email::"))
-        assertThat(userMemcacheRepo.getById(testUser.id).get().email, Is("::new-email::"))
-    }
-
-    @Test
-    fun shouldDeleteUserFromCache(){
-
-        context.expecting {
-            oneOf(mockPersistentRepository).registerIfNotExists(testRegistrationRequest)
-            will(returnValue(testUser))
-
-            oneOf(mockPersistentRepository).deleteById(testUser.id)
-
-            oneOf(mockPersistentRepository).getById(testUser.id)
-            will(returnValue(Optional.empty<User>()))
-            oneOf(mockPersistentRepository).getByUsername(testUser.username)
-            will(returnValue(Optional.empty<User>()))
-        }
-
-        userMemcacheRepo.registerIfNotExists(testRegistrationRequest)
-        userMemcacheRepo.deleteById(testUser.id)
-        assertThat(userMemcacheRepo.getById(testUser.id).isPresent, Is(false))
-        assertThat(userMemcacheRepo.getByUsername(testUser.username).isPresent, Is(false))
-    }
-
-    private fun key(key: Any): String{
-        return "${idPrefix}_$key"
+        assertThat(usersCache.get(user.id).isPresent, Is(false))
+        assertThat(usersCache.get(user.username).isPresent, Is(false))
     }
 }

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/core/SessionsDecoratorTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/core/SessionsDecoratorTest.kt
@@ -1,0 +1,110 @@
+package com.clouway.bankapp.core
+
+import org.junit.Test
+import java.time.LocalDateTime
+import org.hamcrest.CoreMatchers.`is` as Is
+import org.junit.Assert.assertThat
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class SessionsDecoratorTest {
+
+    private val sessionCache = InMemorySessionsCache()
+    private val sessionRepository = InMemorySessions()
+    private val sessions = SessionsDecorator(sessionCache,
+            sessionRepository)
+
+    private val instant = LocalDateTime.of(1, 1, 1, 1, 1, 1)
+
+    private val sessionRequest = SessionRequest(
+            "::userId::",
+            "::sid::",
+            "::username::",
+            "::user-email::",
+            instant
+    )
+
+    private val session = Session(
+            "::userId::",
+            "::sid::",
+            instant,
+            "::username::",
+            "::user-email::",
+            true
+    )
+
+    @Test
+    fun returnSavedSession(){
+        assertThat(sessions.issueSession(sessionRequest), Is(session))
+    }
+
+    @Test
+    fun returnEmptyWhenExpiredSession(){
+        sessions.issueSession(sessionRequest)
+
+        assertThat(sessions.getSessionAvailableAt(sessionRequest.sessionId, instant.plusDays(1)).isPresent,
+                Is(false))
+    }
+
+    @Test
+    fun returnEmptyWhenNotFound(){
+        assertThat(sessions.getSessionAvailableAt(sessionRequest.sessionId, instant.plusDays(1)).isPresent,
+                Is(false))
+    }
+
+    @Test
+    fun saveSessionInCache(){
+        sessions.issueSession(sessionRequest)
+
+        assertThat(sessionCache.get(sessionRequest.sessionId).isPresent, Is(true))
+        assertThat(sessionCache.get(sessionRequest.sessionId).get(), Is(session))
+    }
+
+    @Test
+    fun saveSessionInPersistence(){
+        sessions.issueSession(sessionRequest)
+
+        assertThat(sessionRepository.getSessionAvailableAt(sessionRequest.sessionId,
+                instant.minusDays(1)).isPresent,
+                Is(true))
+        assertThat(sessionRepository.getSessionAvailableAt(sessionRequest.sessionId,
+                instant.minusDays(1)).get(),
+                Is(session))
+    }
+
+    @Test
+    fun retrieveSession(){
+        sessions.issueSession(sessionRequest)
+
+
+        assertThat(sessions.getSessionAvailableAt(sessionRequest.sessionId,
+                instant.minusDays(1)).isPresent, Is(true))
+        assertThat(sessions.getSessionAvailableAt(sessionRequest.sessionId,
+                instant.minusDays(1)).get(), Is(session))
+    }
+
+    @Test
+    fun terminateSession(){
+        sessions.issueSession(sessionRequest)
+
+        sessions.terminateSession(sessionRequest.sessionId)
+
+        assertThat(sessions.getSessionAvailableAt(sessionRequest.sessionId, instant.minusDays(1)).isPresent,
+                Is(false))
+    }
+
+    @Test
+    fun saveSessionToCacheIfRetrievedFromPersistence(){
+
+        sessions.issueSession(sessionRequest)
+
+        sessionCache.remove(sessionRequest.sessionId)
+
+        sessions.getSessionAvailableAt(sessionRequest.sessionId,
+                instant.minusDays(1))
+
+        assertThat(sessionCache.get(sessionRequest.sessionId).isPresent, Is(true))
+        assertThat(sessionCache.get(sessionRequest.sessionId).get(), Is(session))
+    }
+}

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/core/UsersDecoratorTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/core/UsersDecoratorTest.kt
@@ -1,0 +1,111 @@
+package com.clouway.bankapp.core
+
+import org.apache.http.annotation.NotThreadSafe
+import org.junit.Test
+import org.hamcrest.CoreMatchers.`is` as Is
+import org.junit.Assert.assertThat
+
+/**
+ * @author Tsvetozar Bonev (tsbonev@gmail.com)
+ */
+class UsersDecoratorTest {
+
+    private val usersCache = InMemoryUsersCache()
+    private val usersRepository = InMemoryUsers()
+
+    private val users = UsersDecorator(usersCache, usersRepository)
+
+    private val registrationRequest = UserRegistrationRequest(
+            "::username::",
+            "::email::",
+            "::password::"
+    )
+
+    private val user = User(
+            "::id::",
+            "::username::",
+            "::email::",
+            "::password::"
+    )
+
+    @Test
+    fun returnRegisteredUser(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+        assertThat(registeredUser.copy(id = "::id::"), Is(user))
+    }
+
+    @Test
+    fun saveUserInCache(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+
+        assertThat(usersCache.get(registeredUser.username).isPresent, Is(true))
+        assertThat(usersCache.get(registeredUser.id).isPresent, Is(true))
+    }
+
+    @Test
+    fun saveUserInPersistence(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+
+        assertThat(usersRepository.getByUsername(registeredUser.username).isPresent, Is(true))
+        assertThat(usersRepository.getById(registeredUser.id).isPresent, Is(true))
+    }
+
+    @Test(expected = UserAlreadyExistsException::class)
+    fun rejectRegisteringExistingUser(){
+        users.registerIfNotExists(registrationRequest)
+        users.registerIfNotExists(registrationRequest)
+    }
+
+    @Test
+    fun retrieveUserById(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+
+        assertThat(users.getById(registeredUser.id).isPresent, Is(true))
+        assertThat(users.getById(registeredUser.id).get(), Is(registeredUser))
+    }
+
+    @Test
+    fun retrieveUserByUsername(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+
+        assertThat(users.getByUsername(registeredUser.username).isPresent, Is(true))
+        assertThat(users.getByUsername(registeredUser.username).get(), Is(registeredUser))
+    }
+
+    @Test
+    fun saveUserInCacheIfRetrievedFromPersistence(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+
+        usersCache.remove(registeredUser.id)
+        users.getById(registeredUser.id)
+
+        assertThat(usersCache.get(registeredUser.id).isPresent, Is(true))
+    }
+
+    @Test
+    fun updateUser(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+        val updatedUser = registeredUser.copy(email = "::new-email::")
+
+        users.update(updatedUser)
+
+        assertThat(users.getById(registeredUser.id).isPresent, Is(true))
+        assertThat(users.getById(registeredUser.id).get(), Is(updatedUser))
+    }
+
+    @Test
+    fun returnEmptyWhenNotFound(){
+        assertThat(usersCache.get(user.id).isPresent, Is(false))
+        assertThat(usersCache.get(user.username).isPresent, Is(false))
+    }
+
+    @Test
+    fun deleteUser(){
+        val registeredUser = users.registerIfNotExists(registrationRequest)
+
+        users.deleteById(registeredUser.id)
+
+        assertThat(users.getByUsername(registeredUser.username).isPresent, Is(false))
+        assertThat(users.getByUsername(registeredUser.id).isPresent, Is(false))
+    }
+}


### PR DESCRIPTION
Rewrote sessions so that a decorator is used and a session cache and session repository can be injected at instantiation. Closes #62.