### PR TITLE
pubsub: made push endpoints the same

### DIFF
--- a/loggingservice/src/main/kotlin/server/AppBootstrap.kt
+++ b/loggingservice/src/main/kotlin/server/AppBootstrap.kt
@@ -16,7 +16,7 @@ class AppBootstrap : SparkApplication {
 
         val projectId = ServiceOptions.getDefaultProjectId()
         val logServiceUrl = "https://log-dot-$projectId.appspot.com"
-        val pushUrl = "/_ah/push-handlers/pubsub/log"
+        val pushUrl = "/_ah/push-handlers/pubsub/message"
 
         val logger = DatastoreLogger()
 
@@ -31,8 +31,8 @@ class AppBootstrap : SparkApplication {
 
         eventBus.subscribe("user-change",
                 "user-change-logging-service",
-                "$logServiceUrl$pushUrl/message")
+                "$logServiceUrl$pushUrl")
 
-        post("$pushUrl/message", eventBus.register(handlerMap))
+        post(pushUrl, eventBus.register(handlerMap))
     }
 }

--- a/mailservice/src/main/kotlin/server/AppBootstrap.kt
+++ b/mailservice/src/main/kotlin/server/AppBootstrap.kt
@@ -23,7 +23,7 @@ class AppBootstrap : SparkApplication {
 
         val projectId = ServiceOptions.getDefaultProjectId()
         val mailServiceUrl = "https://mail-dot-$projectId.appspot.com"
-        val pushUrl = "/_ah/push-handlers/pubsub/mail"
+        val pushUrl = "/_ah/push-handlers/pubsub/message"
 
         val eventBus = EventBusFactory.createAsyncPubsubEventBus()
 
@@ -53,9 +53,9 @@ class AppBootstrap : SparkApplication {
 
         eventBus.subscribe("user-change",
                 "user-change-mail-service",
-                "$mailServiceUrl$pushUrl/message")
+                "$mailServiceUrl$pushUrl")
 
-        post("$pushUrl/message", eventBus.register(handlerMap))
+        post(pushUrl, eventBus.register(handlerMap))
 
     }
 }


### PR DESCRIPTION
Removed the microservice name from all microservice endpoints and changed them all to be /_ah/push-handlers/pubsub/message. Closes #67.