### PR TITLE
users: removed optional register request id

### DIFF
--- a/bankapp/src/main/kotlin/com/clouway/bankapp/adapter/gae/datastore/DatastoreUsers.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/adapter/gae/datastore/DatastoreUsers.kt
@@ -60,7 +60,7 @@ class DatastoreUsers : Users {
 
     override fun registerIfNotExists(registerRequest: UserRegistrationRequest): User {
 
-        val user = User(registerRequest.id ?: UUID.randomUUID().toString(),
+        val user = User(UUID.randomUUID().toString(),
                 registerRequest.username,
                 registerRequest.email,
                 registerRequest.password)

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/UserRegistrationRequest.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/UserRegistrationRequest.kt
@@ -3,4 +3,4 @@ package com.clouway.bankapp.core
 /**
  * @author Tsvetozar Bonev (tsbonev@gmail.com)
  */
-data class UserRegistrationRequest(val username: String, val email: String, val password: String, val id: String?)
+data class UserRegistrationRequest(val username: String, val email: String, val password: String)

--- a/bankapp/src/main/kotlin/com/clouway/bankapp/core/security/MD5PasswordHasher.kt
+++ b/bankapp/src/main/kotlin/com/clouway/bankapp/core/security/MD5PasswordHasher.kt
@@ -15,8 +15,7 @@ class MD5PasswordHasher : PasswordHasher {
         return UserRegistrationRequest(
                 request.username,
                 request.email,
-                Credential.MD5.digest(request.password).removePrefix("MD5:"),
-                request.id
+                Credential.MD5.digest(request.password).removePrefix("MD5:")
         )
     }
 }

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/datastore/DatastoreUsersTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/datastore/DatastoreUsersTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.junit.Assert.assertThat
 import org.junit.Rule
 import rule.DatastoreRule
-import java.util.*
 import org.hamcrest.CoreMatchers.`is` as Is
 
 /**
@@ -22,64 +21,54 @@ class DatastoreUsersTest {
 
     private val userRepo = DatastoreUsers()
 
-    private val testId = UUID.randomUUID().toString()
-    private val registerJohn = UserRegistrationRequest("John", "email", "password", testId)
-    private val userJohn = User(testId, "John", "email", "password")
+    private val registrationRequest = UserRegistrationRequest("::username::", "::email::", "::password::")
+    private val user = User("::userId::", "::username::", "::email::", "::password::")
 
     @Test
-    fun shouldRegisterUser(){
-
-        val user = userRepo.registerIfNotExists(registerJohn)
+    fun returnRegisteredUser(){
+        val user = userRepo.registerIfNotExists(registrationRequest)
 
         assertThat(userRepo.getById(user.id).get() == user, Is(true))
-
     }
 
     @Test(expected = UserAlreadyExistsException::class)
-    fun shouldNotRegisterUserTwice(){
-
-        userRepo.registerIfNotExists(registerJohn)
-        userRepo.registerIfNotExists(registerJohn)
-
+    fun rejectRegistrationOfExistingUser(){
+        userRepo.registerIfNotExists(registrationRequest)
+        userRepo.registerIfNotExists(registrationRequest)
     }
 
     @Test
-    fun shouldGetByUsername(){
+    fun retrieveUserByUsername(){
+        val user = userRepo.registerIfNotExists(registrationRequest)
 
-        val user = userRepo.registerIfNotExists(registerJohn)
-
-        assertThat(userRepo.getByUsername(registerJohn.username).get(),
+        assertThat(userRepo.getByUsername(registrationRequest.username).get(),
                 Is(user))
-
     }
 
     @Test
-    fun shouldNotFindByUsername(){
-
-        assertThat(userRepo.getByUsername(userJohn.username).isPresent, Is(false))
-
-    }
-
-    @Test
-    fun shouldDeleteUserById(){
-
-        val user = userRepo.registerIfNotExists(UserRegistrationRequest("John", "email", "password", testId))
-
-        assertThat(userRepo.getById(user.id).isPresent, Is(true))
-
-        userRepo.deleteById(user.id)
+    fun returnEmptyWhenNotFound(){
+        assertThat(userRepo.getByUsername(user.username).isPresent, Is(false))
         assertThat(userRepo.getById(user.id).isPresent, Is(false))
     }
 
     @Test
-    fun shouldUpdateUser(){
+    fun deleteById(){
+        val user = userRepo.registerIfNotExists(UserRegistrationRequest("John", "email", "password"))
 
-        userRepo.registerIfNotExists(UserRegistrationRequest("John", "email", "password", testId))
+        userRepo.deleteById(user.id)
 
-        val userJohn = User(testId, "Don", "email", "password")
+        assertThat(userRepo.getById(user.id).isPresent, Is(false))
+        assertThat(userRepo.getByUsername(user.username).isPresent, Is(false))
+    }
 
-        userRepo.update(userJohn)
+    @Test
+    fun updateUser(){
+        val registeredUser = userRepo.registerIfNotExists(registrationRequest)
 
-        assertThat(userRepo.getById(testId).get().username, Is("Don"))
+        val updatedUser = registeredUser.copy(email = "::new-email::")
+
+        userRepo.update(updatedUser)
+
+        assertThat(userRepo.getById(registeredUser.id).get(), Is(updatedUser))
     }
 }

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/memcache/MemcacheUsersTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/memcache/MemcacheUsersTest.kt
@@ -37,7 +37,7 @@ class MemcacheUsersTest {
     private val testId = UUID.randomUUID().toString()
 
     private val testUser = User(testId, "::username::", "::email::", "::password::")
-    private val testRegistrationRequest = UserRegistrationRequest("::username::", "::email::", "::password::", testId)
+    private val testRegistrationRequest = UserRegistrationRequest("::username::", "::email::", "::password::")
 
     private val mockPersistentRepository = context.mock(Users::class.java)
 

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/spark/LoginSystemTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/adapter/spark/LoginSystemTest.kt
@@ -72,7 +72,7 @@ class LoginSystemTest {
 
     private val testId = UUID.randomUUID().toString()
     private val testUser = User(testId, "John", "email", "password")
-    private val testUserRegistrationRequest = UserRegistrationRequest("John","email", "password", testId)
+    private val testUserRegistrationRequest = UserRegistrationRequest("John","email", "password")
     private val testUserLoginRequest = UserLoginRequest("John","password")
     private val possibleUser = Optional.of(testUser)
     private val testSession = Session(testId, SID, testDate, "John", "email")

--- a/bankapp/src/test/kotlin/com/clouway/bankapp/core/security/MD5PasswordHasherTest.kt
+++ b/bankapp/src/test/kotlin/com/clouway/bankapp/core/security/MD5PasswordHasherTest.kt
@@ -13,7 +13,7 @@ class MD5PasswordHasherTest {
 
     private val hasher = MD5PasswordHasher()
 
-    private val registerRequest = UserRegistrationRequest("::username::", "::email::", "::password::", UUID.randomUUID().toString())
+    private val registerRequest = UserRegistrationRequest("::username::", "::email::", "::password::")
 
     @Test
     fun shouldHashAndMatchPassword(){


### PR DESCRIPTION
Removed the optional id in the register request and cleaned up the user datastore tests. Closes #75.